### PR TITLE
fix: Accrue Yield Before Fee Change

### DIFF
--- a/src/ATokenVault.sol
+++ b/src/ATokenVault.sol
@@ -350,6 +350,8 @@ contract ATokenVault is ERC4626, Ownable {
     function setFee(uint256 newFee) public onlyOwner {
         require(newFee <= SCALE, "FEE_TOO_HIGH");
 
+        _accrueYield();
+
         uint256 oldFee = _fee;
         _fee = newFee;
 


### PR DESCRIPTION
Closes #35 

This PR adds a call to `_accrueYield()` before changing the fee amount, so that the new fee is not retroactively applied to accumulated yield.