### PR TITLE
Changing version of aave-v3-core

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 [submodule "lib/aave-v3-core"]
 	path = lib/aave-v3-core
 	url = https://github.com/aave/aave-v3-core
-	branch = v1.17.1
+	branch = v1.19.1
 [submodule "lib/erc4626-tests"]
 	path = lib/erc4626-tests
 	url = https://github.com/a16z/erc4626-tests


### PR DESCRIPTION
Currently it is impossible to import aave-vault to another project with any solidity version besides 0.8.10 because of version of aave-v3-core repo where aave-v3-core/contracts/dependencies/openzeppelin/contracts/IERC20.sol has fixed solidity version 0.8.10, but now it's softened