### PR TITLE
fix: set evm version

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 solc = "0.8.10"
 bytecode_hash = "none"
+evm_version = "shanghai"
 optimizer = true
 optimizer-runs = 10_000_000
 via_ir = false


### PR DESCRIPTION
Set evm version in `foundry.toml` to fix revert error

```
~/aave/aave-vault$ forge script script/Deploy.s.sol:Deploy --rpc-url $POLYGON_RPC_URL --broadcast --verify --legacy -vvvv

[⠊] Compiling...
[⠃] Compiling 1 files with Solc 0.8.10
[⠊] Solc 0.8.10 finished in 798.77ms
Compiler run successful with warnings:
Warning (2519): This declaration shadows an existing declaration.
  --> lib/aave-v3-core/contracts/protocol/tokenization/base/IncentivizedERC20.sol:74:5:
   |
74 |     string memory name,
   |     ^^^^^^^^^^^^^^^^^^
Note: The shadowed declaration is here:
  --> lib/aave-v3-core/contracts/protocol/tokenization/base/IncentivizedERC20.sol:86:3:
   |
86 |   function name() public view override returns (string memory) {
   |   ^ (Relevant source part starts here and spans across multiple lines).

Warning (8760): This declaration has the same name as another declaration.
  --> lib/aave-v3-core/contracts/protocol/tokenization/base/IncentivizedERC20.sol:75:5:
   |
75 |     string memory symbol,
   |     ^^^^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
  --> lib/aave-v3-core/contracts/protocol/tokenization/base/IncentivizedERC20.sol:91:3:
   |
91 |   function symbol() external view override returns (string memory) {
   |   ^ (Relevant source part starts here and spans across multiple lines).

Warning (8760): This declaration has the same name as another declaration.
  --> lib/aave-v3-core/contracts/protocol/tokenization/base/IncentivizedERC20.sol:76:5:
   |
76 |     uint8 decimals
   |     ^^^^^^^^^^^^^^
Note: The other declaration is here:
  --> lib/aave-v3-core/contracts/protocol/tokenization/base/IncentivizedERC20.sol:96:3:
   |
96 |   function decimals() external view override returns (uint8) {
   |   ^ (Relevant source part starts here and spans across multiple lines).

Traces:
  [7298628] → new Deploy@0x9f7cF1d1F558E57ef88a59ac3D47214eF25B6A06
    └─ ← [Return] 36225 bytes of code

  [1024208712] Deploy::run()
    ├─ [0] VM::envUint("PRIVATE_KEY")
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::addr(<pk>)
    │   └─ ← [Return] 0xF74360278e181FdCFdfA694687cF53FC163dEe18
    ├─ [0] console::log("Deployer address: ", 0xF74360278e181FdCFdfA694687cF53FC163dEe18) [staticcall]
    │   └─ ← [Stop]
    ├─ [0] console::9710a9d0(0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000af5f5866024f100000000000000000000000000000000000000000000000000000000000000124465706c6f7965722062616c616e63653a200000000000000000000000000000) [staticcall]
    │   └─ ← [Revert] unknown selector `0x9710a9d0` for ConsoleCalls
    ├─ [0] console::9710a9d0(000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000015b780d000000000000000000000000000000000000000000000000000000000000000d426c6f636b4e756d6265723a2000000000000000000000000000000000000000) [staticcall]
    │   └─ ← [Revert] unknown selector `0x9710a9d0` for ConsoleCalls
    ├─ [0] console::9710a9d0(0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000a4b10000000000000000000000000000000000000000000000000000000000000009436861696e49643a200000000000000000000000000000000000000000000000) [staticcall]
    │   └─ ← [Revert] unknown selector `0x9710a9d0` for ConsoleCalls
    ├─ [0] console::log("Deploying vault...") [staticcall]
    │   └─ ← [Stop]
    ├─ [0] VM::startBroadcast(<pk>)
    │   └─ ← [Return]
    ├─ [1024151396] → new <unknown>@0x5aAdFB43eF8dAF45DD80F4676345b7676f1D70e3
    │   ├─ emit Initialized(version: 255)
    │   ├─ [2350] 0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb::getPool() [staticcall]
    │   │   └─ ← [Return] 0x794a61358D6845594F94dc1DB02A252b5b4814aD
    │   ├─ [1023728770] 0x794a61358D6845594F94dc1DB02A252b5b4814aD::getReserveData(0xaf88d065e77c8cC2239327C5EDb3A432268e5831) [staticcall]
    │   │   ├─ [63] 0x7f775bb7af2e7E09D5Dc9506c95516159a5cA0D0::getReserveData(0xaf88d065e77c8cC2239327C5EDb3A432268e5831) [delegatecall]
    │   │   │   └─ ← [NotActivated] EvmError: NotActivated
    │   │   └─ ← [Revert] EvmError: Revert
    │   └─ ← [Revert]
    └─ ← [Revert] EvmError: Revert
```