### PR TITLE
feat: Return addresses and amounts of claimed rewards

### DIFF
--- a/src/ATokenVault.sol
+++ b/src/ATokenVault.sol
@@ -431,7 +431,7 @@ contract ATokenVault is ERC4626Upgradeable, OwnableUpgradeable, EIP712Upgradeabl
     }
 
     /// @inheritdoc IATokenVault
-    function claimRewards(address to) public override onlyOwner {
+    function claimRewards(address to) public override onlyOwner returns (address[] memory, uint256[] memory) {
         require(to != address(0), "CANNOT_CLAIM_TO_ZERO_ADDRESS");
 
         address[] memory assets = new address[](1);
@@ -441,6 +441,8 @@ contract ATokenVault is ERC4626Upgradeable, OwnableUpgradeable, EIP712Upgradeabl
         ).claimAllRewards(assets, to);
 
         emit RewardsClaimed(to, rewardsList, claimedAmounts);
+
+        return (rewardsList, claimedAmounts);
     }
 
     /// @inheritdoc IATokenVault

--- a/src/interfaces/IATokenVault.sol
+++ b/src/interfaces/IATokenVault.sol
@@ -394,8 +394,10 @@ interface IATokenVault is IERC4626Upgradeable {
      * @notice Claims any additional Aave rewards earned from vault deposits.
      * @dev Only callable by the owner
      * @param to The address to receive any rewards tokens
+     * @return The list of addresses of the rewards that have been claimed
+     * @return The list of amounts of rewards that have been claimed
      */
-    function claimRewards(address to) external;
+    function claimRewards(address to) external returns (address[] memory, uint256[] memory);
 
     /**
      * @notice Rescue any tokens other than the vault's aToken which may have accidentally been transferred to this


### PR DESCRIPTION
For distributing fees and rewards across different beneficiaries it is a requirement to know the assets and amounts claimed.

For the fees we already have `getClaimableFees` function which works well for the purpose. Howerver, for rewards we do not have such getter.

As a solution, I am suggesting this modification to get the assets and amounts of the claimed rewards.